### PR TITLE
feat: Add code completion and annotator support for steps.*.{conclusion,outcome}

### DIFF
--- a/src/main/java/com/github/yunabraska/githubworkflow/helper/GitHubWorkflowConfig.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/helper/GitHubWorkflowConfig.java
@@ -30,6 +30,8 @@ public class GitHubWorkflowConfig {
     public static final String FIELD_INPUTS = "inputs";
     public static final String FIELD_OUTPUTS = "outputs";
     public static final String FIELD_SECRETS = "secrets";
+    public static final String FIELD_CONCLUSION = "conclusion";
+    public static final String FIELD_OUTCOME = "outcome";
     public static final Map<String, Supplier<Map<String, String>>> DEFAULT_VALUE_MAP = initProcessorMap();
 
     private static Map<String, Supplier<Map<String, String>>> initProcessorMap() {

--- a/src/main/java/com/github/yunabraska/githubworkflow/helper/HighlightAnnotatorHelper.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/helper/HighlightAnnotatorHelper.java
@@ -29,8 +29,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.FIELD_OUTPUTS;
-import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.FIELD_USES;
+import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.*;
 import static com.github.yunabraska.githubworkflow.helper.PsiElementHelper.removeQuotes;
 import static com.github.yunabraska.githubworkflow.model.NodeIcon.JUMP_TO_IMPLEMENTATION;
 import static com.github.yunabraska.githubworkflow.model.NodeIcon.RELOAD;
@@ -101,7 +100,7 @@ public class HighlightAnnotatorHelper {
     }
 
     public static boolean isField2Valid(@NotNull final PsiElement psiElement, @NotNull final AnnotationHolder holder, final SimpleElement itemId) {
-        if (!FIELD_OUTPUTS.equals(itemId.text())) {
+        if (!List.of(FIELD_OUTPUTS, FIELD_CONCLUSION, FIELD_OUTCOME).contains(itemId.text())) {
             final TextRange textRange = simpleTextRange(psiElement, itemId);
             new SyntaxAnnotation(
                     "Remove invalid [" + itemId + "]",

--- a/src/main/java/com/github/yunabraska/githubworkflow/services/CodeCompletion.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/services/CodeCompletion.java
@@ -137,8 +137,13 @@ public class CodeCompletion extends CompletionContributor {
 
     private static void handleSecondItem(final String[] cbi, final int i, final Map<Integer, List<SimpleElement>> completionItemMap) {
         switch (cbi[0]) {
-            case FIELD_JOBS, FIELD_NEEDS, FIELD_STEPS ->
-                    completionItemMap.put(i, singletonList(completionItemOf(FIELD_OUTPUTS, "", ICON_OUTPUT)));
+            case FIELD_JOBS, FIELD_NEEDS, FIELD_STEPS -> {
+                completionItemMap.put(i, List.of(
+                    completionItemOf(FIELD_OUTPUTS, "The set of outputs defined for the step.", ICON_OUTPUT),
+                    completionItemOf(FIELD_CONCLUSION, "The result of a completed step after continue-on-error is applied.", ICON_OUTPUT),
+                    completionItemOf(FIELD_OUTCOME, "The result of a completed step before continue-on-error is applied.", ICON_OUTPUT)
+                ));
+            }
             default -> {
                 // ignored
             }

--- a/src/main/java/com/github/yunabraska/githubworkflow/services/HighlightAnnotator.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/services/HighlightAnnotator.java
@@ -5,6 +5,7 @@ import com.github.yunabraska.githubworkflow.model.GitHubAction;
 import com.github.yunabraska.githubworkflow.model.IconRenderer;
 import com.github.yunabraska.githubworkflow.model.SimpleElement;
 import com.github.yunabraska.githubworkflow.model.SyntaxAnnotation;
+import com.google.common.collect.Iterables;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
@@ -221,14 +222,21 @@ public class HighlightAnnotator implements Annotator {
                                         ifEnoughItems(holder, element, parts, 2, -1, envId -> isDefinedItem0(element, holder, envId, new ArrayList<>(DEFAULT_VALUE_MAP.get(FIELD_GITHUB).get().keySet())));
                                 case FIELD_RUNNER ->
                                         ifEnoughItems(holder, element, parts, 2, 2, runnerId -> isDefinedItem0(element, holder, runnerId, new ArrayList<>(DEFAULT_VALUE_MAP.get(FIELD_RUNNER).get().keySet())));
-                                case FIELD_STEPS -> ifEnoughItems(holder, element, parts, 4, 4, stepId -> {
-                                    final List<YAMLSequenceItem> steps = listSteps(element);
-                                    if (isDefinedItem0(element, holder, stepId, steps.stream().map(step -> getText(step, FIELD_ID).orElse(null)).filter(Objects::nonNull).toList()) && isField2Valid(element, holder, parts[2])) {
-                                        final List<String> outputs = listStepOutputs(steps.stream().filter(step -> getText(step, FIELD_ID).filter(id -> id.equals(stepId.text())).isPresent()).findFirst().orElse(null)).stream().map(SimpleElement::key).toList();
-                                        isValidItem3(element, holder, parts[3], outputs);
-
+                                case FIELD_STEPS -> {
+                                    if (parts.length > 2 && List.of(FIELD_CONCLUSION, FIELD_OUTCOME).contains(parts[2].text())) {
+                                        ifEnoughItems(holder, element, parts, 3, 3, __ -> {
+                                            isField2Valid(element, holder, parts[2]);
+                                        });
+                                    } else {
+                                        ifEnoughItems(holder, element, parts, 4, 4, stepId -> {
+                                            final List<YAMLSequenceItem> steps = listSteps(element);
+                                            if (isDefinedItem0(element, holder, stepId, steps.stream().map(step -> getText(step, FIELD_ID).orElse(null)).filter(Objects::nonNull).toList()) && isField2Valid(element, holder, parts[2])) {
+                                                final List<String> outputs = listStepOutputs(steps.stream().filter(step -> getText(step, FIELD_ID).filter(id -> id.equals(stepId.text())).isPresent()).findFirst().orElse(null)).stream().map(SimpleElement::key).toList();
+                                                isValidItem3(element, holder, parts[3], outputs);
+                                            }
+                                        });
                                     }
-                                });
+                                }
                                 case FIELD_JOBS -> ifEnoughItems(holder, element, parts, 4, 4, jobId -> {
                                     final List<YAMLKeyValue> jobs = listJobs(element);
                                     if (isDefinedItem0(element, holder, jobId, jobs.stream().map(YAMLKeyValue::getKeyText).toList()) && isField2Valid(element, holder, parts[2])) {

--- a/src/test/resources/testdata/.github/show_case.yml
+++ b/src/test/resources/testdata/.github/show_case.yml
@@ -78,6 +78,8 @@ jobs:
           echo "custom_env    [${{ env.custom_env_key }}]"
           echo "input_1       [${{ inputs.input_1 }}]"
           echo "SECRET_1      [${{ secrets.SECRET_1 }}]"
+          echo "outcome       [${{ steps.my_variables.outcome }}]"
+          echo "conclusion    [${{ steps.my_variables.conclusion }}]"
         env:
           step_env_1: "My Step Env 1"
           step_env_2: "My Step Env 2"


### PR DESCRIPTION
### Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation
> Why is this change required? What problem does it solve?

Code completion and annotation is incomplete for items under steps.* other than `outputs`.

## Changes
> Behaviour, Functionality, Screenshots, etc.

This pull request adds code completion and annotator support for `steps.*.conclusion` and `steps.*.outcome`. These properties are documented at https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context.

<img width="930" alt="image" src="https://github.com/YunaBraska/github-workflow-plugin/assets/12772118/3889406c-1f29-4714-8ca6-56d119b67f3b">

## Success Check
> How can we see or measure the change?

Try opening this simple workflow:

```yaml
name: checks

on:
  pull_request: ~

jobs:
  checks:
    runs-on: ubuntu-22.04
    steps:
      - uses: actions/checkout@v4
        id: checkout

      - run: echo "${{ steps.checkout.outcome }}"
```