### PR TITLE
feat: Add jacoco coverage support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ fun environment(key: String) = providers.environmentVariable(key)
 plugins {
     // Java support
     id("java")
+    // Jacoco support
+    id("jacoco")
     // Gradle IntelliJ Plugin
     id("org.jetbrains.intellij") version "1.15.0"
     // Gradle Changelog Plugin
@@ -125,5 +127,18 @@ tasks {
     withType<Test> {
         systemProperty("idea.test.execution.policy", "com.github.yunabraska.githubworkflow.services.PluginExecutionPolicy")
         systemProperty("PLUGIN_HOME_PATH", rootProject.file("src/test/resources"))
+        configure<JacocoTaskExtension> {
+            isIncludeNoLocationClasses = true
+            excludes = listOf("jdk.internal.*")
+        }
+        finalizedBy(jacocoTestReport)
+
+        jacocoTestReport {
+            classDirectories.setFrom(instrumentCode)
+        }
+
+        jacocoTestCoverageVerification {
+            classDirectories.setFrom(instrumentCode)
+        }
     }
 }


### PR DESCRIPTION
<!-- Closes #000 -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation
> Why is this change required? What problem does it solve?

JaCoCo is introduced in order to give a better way to see the covered code by tests, and then implement missing tests.

## Changes
> Behaviour, Functionality, Screenshots, etc.

Html report is rendered like in the following capture : 
<img width="1187" alt="image" src="https://github.com/YunaBraska/github-workflow-plugin/assets/12534707/a29c8aed-6047-4380-9c1a-f66cd300e825">


## Success Check
> How can we see or measure the change?

By running tests, the coverage report is generated under the `build/reports/jacoco/test/html/index.html`, other kinds of reports can be generated like `json` and `xml` formats, by configuring the `jacocoTestReport` task.

