### PR TITLE
Fix workflow config static localization

### DIFF
--- a/src/main/java/com/github/yunabraska/githubworkflow/helper/GitHubWorkflowConfig.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/helper/GitHubWorkflowConfig.java
@@ -52,7 +52,15 @@ public class GitHubWorkflowConfig {
     public static final String FIELD_CONCLUSION = "conclusion";
     public static final String FIELD_OUTCOME = "outcome";
     public static final Map<String, Supplier<Map<String, String>>> DEFAULT_VALUE_MAP = initProcessorMap();
-    public static final Map<String, String> SHELLS = initShells();
+
+    /**
+     * Returns shell completion values with descriptions localized at call time.
+     *
+     * @return immutable shell command descriptions for the current plugin language setting
+     */
+    public static Map<String, String> shells() {
+        return initShells();
+    }
 
     private static Map<String, Supplier<Map<String, String>>> initProcessorMap() {
         final Map<String, Supplier<Map<String, String>>> result = new LinkedHashMap<>();

--- a/src/main/java/com/github/yunabraska/githubworkflow/services/CodeCompletion.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/services/CodeCompletion.java
@@ -155,7 +155,7 @@ public class CodeCompletion extends CompletionContributor {
                         } else if (isCompletingShellField(parameters, position)) {
                             addLookupElements(
                                     resultSet.withPrefixMatcher(getDefaultPrefix(parameters)),
-                                    SHELLS,
+                                    shells(),
                                     NodeIcon.ICON_NODE,
                                     Character.MIN_VALUE
                             );

--- a/src/test/java/com/github/yunabraska/githubworkflow/helper/GitHubWorkflowConfigTest.java
+++ b/src/test/java/com/github/yunabraska/githubworkflow/helper/GitHubWorkflowConfigTest.java
@@ -14,6 +14,7 @@ import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.D
 import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.FIELD_ENVS;
 import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.FIELD_GITHUB;
 import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.FIELD_RUNNER;
+import static com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfig.shells;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitHubWorkflowConfigTest {
@@ -143,6 +144,13 @@ public class GitHubWorkflowConfigTest {
                 .contains("debug logging")
                 .contains("1")
                 .doesNotContain("preinstalled tools");
+    }
+
+    @Test
+    public void shellCompletionDescriptionsAreResolvedOnDemand() {
+        assertThat(shells())
+                .containsKeys("bash", "sh", "pwsh", "powershell", "cmd", "python")
+                .doesNotContainValue("");
     }
 
     private static List<String> resourceKeys(final String path) throws Exception {


### PR DESCRIPTION
## Summary
- resolve shell completion labels on demand instead of during `GitHubWorkflowConfig` class initialization
- keep language override behavior while avoiding IntelliJ service lookup from `<clinit>`
- add coverage for shell completion descriptions

## Checks
- `./gradlew test --tests com.github.yunabraska.githubworkflow.helper.GitHubWorkflowConfigTest --no-daemon --warning-mode all`
- `./gradlew test --no-daemon --warning-mode all`

Fixes #87