### PR TITLE
fix: detect grouped workflow outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Step outputs written inside grouped shell redirects to `$GITHUB_OUTPUT` are now recognized.
+
 ## [2026.6.20] - 2026-06-20
 
 ### Plugin Wiring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-- Step outputs written inside grouped shell redirects to `$GITHUB_OUTPUT` are now recognized.
+- Step outputs written inside grouped shell redirects to `$GITHUB_OUTPUT` or `$GITEA_OUTPUT` are now recognized.
 
 ## [2026.6.20] - 2026-06-20
 

--- a/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowContextCatalog.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowContextCatalog.java
@@ -17,11 +17,11 @@ import java.util.regex.Pattern;
 @SuppressWarnings("java:S2386")
 public class WorkflowContextCatalog {
 
-    public static final Pattern PATTERN_GITHUB_OUTPUT = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*>>\\s*\"?\\$\\w*:?\\{?GITHUB_OUTPUT\\}?\"?");
-    public static final Pattern PATTERN_GITHUB_OUTPUT_TEE = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*\\|\\s*tee\\s+(?:-[A-Za-z]+\\s+)*.*\\$\\w*:?\\{?GITHUB_OUTPUT\\}?");
-    public static final Pattern PATTERN_GITHUB_OUTPUT_GROUP = Pattern.compile("(?m)^\\s*\\{\\s*\\R([\\s\\S]*?)^\\s*}\\s*>>\\s*\"?\\$\\w*:?\\{?GITHUB_OUTPUT\\}?\"?");
+    public static final Pattern PATTERN_GITHUB_OUTPUT = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*>>\\s*\"?\\$\\w*:?\\{?(?:GITHUB|GITEA)_OUTPUT\\}?\"?");
+    public static final Pattern PATTERN_GITHUB_OUTPUT_TEE = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*\\|\\s*tee\\s+(?:-[A-Za-z]+\\s+)*.*\\$\\w*:?\\{?(?:GITHUB|GITEA)_OUTPUT\\}?");
+    public static final Pattern PATTERN_GITHUB_OUTPUT_GROUP = Pattern.compile("(?m)^\\s*\\{\\s*\\R([\\s\\S]*?)^\\s*}\\s*>>\\s*\"?\\$\\w*:?\\{?(?:GITHUB|GITEA)_OUTPUT\\}?\"?");
     public static final Pattern PATTERN_SHELL_OUTPUT_ASSIGNMENT = Pattern.compile("(?m)^\\s*(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*;?\\s*$");
-    public static final Pattern PATTERN_GITHUB_ENV = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*>>\\s*\"?\\$\\w*:?\\{?GITHUB_ENV\\}?\"?");
+    public static final Pattern PATTERN_GITHUB_ENV = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*>>\\s*\"?\\$\\w*:?\\{?(?:GITHUB|GITEA)_ENV\\}?\"?");
     public static final Pattern PATTERN_GITHUB_OUTPUT_MULTILINE = Pattern.compile("(?:echo\\s+)?[\"']?([A-Za-z_][A-Za-z0-9_-]*)<<[^\"'\\r\\n]+[\"']?");
     public static final Pattern PATTERN_GITHUB_ENV_MULTILINE = Pattern.compile("(?:echo\\s+)?[\"']?([A-Za-z_][A-Za-z0-9_-]*)<<[^\"'\\r\\n]+[\"']?");
     public static final long CACHE_ONE_DAY = 24L * 60 * 60 * 1000;

--- a/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowContextCatalog.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowContextCatalog.java
@@ -2,8 +2,6 @@ package com.github.yunabraska.githubworkflow.syntax;
 
 import com.github.yunabraska.githubworkflow.i18n.GitHubWorkflowBundle;
 
-
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,6 +19,8 @@ public class WorkflowContextCatalog {
 
     public static final Pattern PATTERN_GITHUB_OUTPUT = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*>>\\s*\"?\\$\\w*:?\\{?GITHUB_OUTPUT\\}?\"?");
     public static final Pattern PATTERN_GITHUB_OUTPUT_TEE = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*\\|\\s*tee\\s+(?:-[A-Za-z]+\\s+)*.*\\$\\w*:?\\{?GITHUB_OUTPUT\\}?");
+    public static final Pattern PATTERN_GITHUB_OUTPUT_GROUP = Pattern.compile("(?m)^\\s*\\{\\s*\\R([\\s\\S]*?)^\\s*}\\s*>>\\s*\"?\\$\\w*:?\\{?GITHUB_OUTPUT\\}?\"?");
+    public static final Pattern PATTERN_SHELL_OUTPUT_ASSIGNMENT = Pattern.compile("(?m)^\\s*(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*;?\\s*$");
     public static final Pattern PATTERN_GITHUB_ENV = Pattern.compile("(?:echo\\s+)?[\"']([A-Za-z_][A-Za-z0-9_-]*)=(.*?)[\"']\\s*>>\\s*\"?\\$\\w*:?\\{?GITHUB_ENV\\}?\"?");
     public static final Pattern PATTERN_GITHUB_OUTPUT_MULTILINE = Pattern.compile("(?:echo\\s+)?[\"']?([A-Za-z_][A-Za-z0-9_-]*)<<[^\"'\\r\\n]+[\"']?");
     public static final Pattern PATTERN_GITHUB_ENV_MULTILINE = Pattern.compile("(?:echo\\s+)?[\"']?([A-Za-z_][A-Za-z0-9_-]*)<<[^\"'\\r\\n]+[\"']?");

--- a/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowPsi.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowPsi.java
@@ -43,8 +43,10 @@ import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog
 import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog.PATTERN_GITHUB_ENV;
 import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog.PATTERN_GITHUB_ENV_MULTILINE;
 import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog.PATTERN_GITHUB_OUTPUT;
+import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog.PATTERN_GITHUB_OUTPUT_GROUP;
 import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog.PATTERN_GITHUB_OUTPUT_MULTILINE;
 import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog.PATTERN_GITHUB_OUTPUT_TEE;
+import static com.github.yunabraska.githubworkflow.syntax.WorkflowContextCatalog.PATTERN_SHELL_OUTPUT_ASSIGNMENT;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Optional.ofNullable;
 
@@ -335,6 +337,7 @@ public class WorkflowPsi {
         if (text.contains("GITHUB_OUTPUT")) {
             putMatches(variables, PATTERN_GITHUB_OUTPUT.matcher(text), false);
             putMatches(variables, PATTERN_GITHUB_OUTPUT_TEE.matcher(text), false);
+            putGroupedOutputMatches(variables, text);
             putMatches(variables, PATTERN_GITHUB_OUTPUT_MULTILINE.matcher(text), true);
         }
         return variables;
@@ -347,6 +350,13 @@ public class WorkflowPsi {
             putMatches(variables, PATTERN_GITHUB_ENV_MULTILINE.matcher(text), true);
         }
         return variables;
+    }
+
+    private static void putGroupedOutputMatches(final Map<String, String> variables, final String text) {
+        final Matcher matcher = PATTERN_GITHUB_OUTPUT_GROUP.matcher(text);
+        while (matcher.find()) {
+            putMatches(variables, PATTERN_SHELL_OUTPUT_ASSIGNMENT.matcher(matcher.group(1)), false);
+        }
     }
 
     private static void putMatches(final Map<String, String> variables, final Matcher matcher, final boolean multiline) {

--- a/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowPsi.java
+++ b/src/main/java/com/github/yunabraska/githubworkflow/syntax/WorkflowPsi.java
@@ -334,7 +334,7 @@ public class WorkflowPsi {
 
     private static Map<String, String> toGithubOutputs(final String text) {
         final Map<String, String> variables = new HashMap<>();
-        if (text.contains("GITHUB_OUTPUT")) {
+        if (text.contains("GITHUB_OUTPUT") || text.contains("GITEA_OUTPUT")) {
             putMatches(variables, PATTERN_GITHUB_OUTPUT.matcher(text), false);
             putMatches(variables, PATTERN_GITHUB_OUTPUT_TEE.matcher(text), false);
             putGroupedOutputMatches(variables, text);
@@ -345,7 +345,7 @@ public class WorkflowPsi {
 
     private static Map<String, String> toGithubEnvs(final String text) {
         final Map<String, String> variables = new HashMap<>();
-        if (text.contains("GITHUB_ENV")) {
+        if (text.contains("GITHUB_ENV") || text.contains("GITEA_ENV")) {
             putMatches(variables, PATTERN_GITHUB_ENV.matcher(text), false);
             putMatches(variables, PATTERN_GITHUB_ENV_MULTILINE.matcher(text), true);
         }

--- a/src/test/java/com/github/yunabraska/githubworkflow/run/WorkflowGutterTest.java
+++ b/src/test/java/com/github/yunabraska/githubworkflow/run/WorkflowGutterTest.java
@@ -183,6 +183,28 @@ public class WorkflowGutterTest extends EditorFeatureTestCase {
         }
     }
 
+    public void testWorkflowDispatchShowsOneRunLineMarker() {
+        configureWorkflowProjectFile("""
+                name: Gutter
+                on:
+                  workflow_dispatch:
+                jobs:
+                  build:
+                    runs-on: ubuntu-latest
+                    steps:
+                      - run: echo ok
+                """);
+        final WorkflowRun.LineMarkerContributor.RepositoryAvailability previous =
+                WorkflowRun.LineMarkerContributor.useRepositoryAvailabilityForTests((project, file) -> true);
+        try {
+            assertThat(myFixture.findAllGutters().stream()
+                    .filter(gutter -> gutter.getIcon() == AllIcons.Actions.Execute)
+                    .count()).isEqualTo(1);
+        } finally {
+            WorkflowRun.LineMarkerContributor.useRepositoryAvailabilityForTests(previous);
+        }
+    }
+
     public void testWorkflowDispatchDoesNotShowRunLineMarkerWithoutGitRepository() {
         configureWorkflowProjectFile("""
                 name: Gutter

--- a/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowSyntaxCompletionTest.java
+++ b/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowSyntaxCompletionTest.java
@@ -1512,6 +1512,25 @@ public class WorkflowSyntaxCompletionTest extends EditorFeatureTestCase {
                 """)).contains("output1", "output2", "output3");
     }
 
+    public void testGiteaStepsOutputCompletionSuggestsGroupedRunOutput() {
+        assertThat(completeGiteaWorkflow("""
+                name: Completion
+                on: workflow_dispatch
+                jobs:
+                  build:
+                    runs-on: ubuntu-latest
+                    steps:
+                      - id: prepare
+                        run: |
+                          echo "output1=value1" >> "${GITEA_OUTPUT}"
+                          {
+                            echo "output2=value2"
+                            echo "output3=value3"
+                          } >> "${GITEA_OUTPUT}"
+                      - run: echo "${{ steps.prepare.outputs.<caret> }}"
+                """)).contains("output1", "output2", "output3");
+    }
+
     public void testBracketStepsOutputCompletionSuggestsRunOutput() {
         assertThat(completeWorkflow("""
                 name: Completion

--- a/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowSyntaxCompletionTest.java
+++ b/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowSyntaxCompletionTest.java
@@ -1493,6 +1493,25 @@ public class WorkflowSyntaxCompletionTest extends EditorFeatureTestCase {
                 """)).contains("artifact");
     }
 
+    public void testStepsOutputCompletionSuggestsGroupedRunOutput() {
+        assertThat(completeWorkflow("""
+                name: Completion
+                on: workflow_dispatch
+                jobs:
+                  build:
+                    runs-on: ubuntu-latest
+                    steps:
+                      - id: prepare
+                        run: |
+                          echo "output1=value1" >> "${GITHUB_OUTPUT}"
+                          {
+                            echo "output2=value2"
+                            echo "output3=value3"
+                          } >> "${GITHUB_OUTPUT}"
+                      - run: echo "${{ steps.prepare.outputs.<caret> }}"
+                """)).contains("output1", "output2", "output3");
+    }
+
     public void testBracketStepsOutputCompletionSuggestsRunOutput() {
         assertThat(completeWorkflow("""
                 name: Completion

--- a/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowValidationTest.java
+++ b/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowValidationTest.java
@@ -1287,6 +1287,32 @@ public class WorkflowValidationTest extends EditorFeatureTestCase {
                 """);
     }
 
+    public void testGiteaStepOutputFromGroupedEchoIsAccepted() {
+        assertGiteaWorkflowHighlights("""
+                name: grouping bug
+                on:
+                  workflow_dispatch:
+                jobs:
+                  grouping-bug:
+                    runs-on: ubuntu-latest
+                    steps:
+                      - name: Prepare outputs
+                        id: prepare
+                        run: |
+                          echo "output1=value1" >> "${GITEA_OUTPUT}"
+
+                          {
+                            echo "output2=value2"
+                            echo "output3=value3"
+                          } >> "${GITEA_OUTPUT}"
+                      - name: Print outputs
+                        run: |
+                          echo "Output 1: ${{ steps.prepare.outputs.output1 }}"
+                          echo "Output 2: ${{ steps.prepare.outputs.output2 }}"
+                          echo "Output 3: ${{ steps.prepare.outputs.output3 }}"
+                """);
+    }
+
     public void testIssue73StepOutputFromTeePipeIsAccepted() {
         assertWorkflowHighlights("""
                 name: Issue 73

--- a/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowValidationTest.java
+++ b/src/test/java/com/github/yunabraska/githubworkflow/syntax/WorkflowValidationTest.java
@@ -1261,6 +1261,32 @@ public class WorkflowValidationTest extends EditorFeatureTestCase {
                 """);
     }
 
+    public void testIssue94StepOutputFromGroupedEchoIsAccepted() {
+        assertWorkflowHighlights("""
+                name: grouping bug
+                on:
+                  workflow_dispatch:
+                jobs:
+                  grouping-bug:
+                    runs-on: ubuntu-latest
+                    steps:
+                      - name: Prepare outputs
+                        id: prepare
+                        run: |
+                          echo "output1=value1" >> "${GITHUB_OUTPUT}"
+
+                          {
+                            echo "output2=value2"
+                            echo "output3=value3"
+                          } >> "${GITHUB_OUTPUT}"
+                      - name: Print outputs
+                        run: |
+                          echo "Output 1: ${{ steps.prepare.outputs.output1 }}"
+                          echo "Output 2: ${{ steps.prepare.outputs.output2 }}"
+                          echo "Output 3: ${{ steps.prepare.outputs.output3 }}"
+                """);
+    }
+
     public void testIssue73StepOutputFromTeePipeIsAccepted() {
         assertWorkflowHighlights("""
                 name: Issue 73


### PR DESCRIPTION
## Summary
- Detect step outputs emitted inside shell groups redirected to `$GITHUB_OUTPUT` or `$GITEA_OUTPUT`.
- Keep direct, `tee`, multiline, and environment file-command parsing intact for GitHub and Gitea names.
- Add regression coverage for issue #94 validation/completion and a one-run-marker gutter sanity check.

## Checks
- `./gradlew --no-daemon test --tests com.github.yunabraska.githubworkflow.syntax.WorkflowValidationTest.testIssue94StepOutputFromGroupedEchoIsAccepted --tests com.github.yunabraska.githubworkflow.syntax.WorkflowSyntaxCompletionTest.testStepsOutputCompletionSuggestsGroupedRunOutput --warning-mode all`
- `./gradlew --no-daemon test --tests com.github.yunabraska.githubworkflow.syntax.WorkflowValidationTest --tests com.github.yunabraska.githubworkflow.syntax.WorkflowSyntaxCompletionTest --tests com.github.yunabraska.githubworkflow.syntax.WorkflowReferencesTest --tests com.github.yunabraska.githubworkflow.run.WorkflowGutterTest --warning-mode all`
- `./gradlew --no-daemon check --warning-mode all`

Fixes #94